### PR TITLE
Use Ruff for auto formatting

### DIFF
--- a/.github/ruff.yml
+++ b/.github/ruff.yml
@@ -7,8 +7,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
         with:
-        src: './src/python'
-        args: 'format --target-version py310'
+          src: './src/python'
+          args: 'format --target-version py310'
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-        commit_message: 'Style fixes by ruff'
+          commit_message: 'Style fixes by ruff'

--- a/.github/ruff.yml
+++ b/.github/ruff.yml
@@ -3,12 +3,18 @@ on: [push, pull_request]
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files.
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: chartboost/ruff-action@v1
         with:
           src: './src/python'
           args: 'format --target-version py310'
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        id: auto-commit-action
         with:
-          commit_message: 'Style fixes by ruff'
+          commit_message: 'Style fixes by Ruff'

--- a/.github/ruff.yml
+++ b/.github/ruff.yml
@@ -1,0 +1,14 @@
+name: Ruff Formatting
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1
+        with:
+        src: './src/python'
+        args: 'format --target-version py310'
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+        commit_message: 'Style fixes by ruff'


### PR DESCRIPTION
Runs `ruff format --target-version py310 ./src/python` on new commits and PRs.

Closes #17 