### PR TITLE
WIP: Add distance metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +686,7 @@ dependencies = [
  "env_logger",
  "log",
  "pyo3",
+ "rayon",
  "sourmash",
 ]
 
@@ -874,6 +900,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ name = "oxli"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version="0.22.3", features = ["extension-module", "anyhow"] }
-sourmash = "0.15.1"
 anyhow = "1.0.89"
-log = "0.4.22"
 env_logger = "0.11.5"
+log = "0.4.22"
+pyo3 = { version="0.22.3", features = ["extension-module", "anyhow"] }
+rayon = "1.10.0"
+sourmash = "0.15.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,6 @@ features = ["pyo3/extension-module"]
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
-    "toml>=0.10"
+    "toml>=0.10",
+    "scipy"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,13 +441,26 @@ impl KmerCountTable {
         Ok(())
     }
 
-    // Jaccard
+    /// Calculates the Jaccard Similarity Coefficient between two KmerCountTable objects.
+    /// # Returns
+    /// The Jaccard Similarity Coefficient between the two tables as a float value between 0 and 1.
+    pub fn jaccard(&self, other: &KmerCountTable) -> f64 {
+        // Get the intersection of the two k-mer sets.
+        let intersection_size = self.intersection(other).len();
+
+        // Get the union of the two k-mer sets.
+        let union_size = self.union(other).len();
+
+        // Handle the case where the union is empty (both sets are empty).
+        if union_size == 0 {
+            return 1.0; // By convention, two empty sets are considered identical.
+        }
+
+        // Calculate and return the Jaccard similarity as a ratio of intersection to union.
+        intersection_size as f64 / union_size as f64
+    }
 
     /// Cosine similarity between two `KmerCountTable` objects.
-    ///
-    /// # Arguments
-    /// * `other` - The second `KmerCountTable` to compare against.
-    ///
     /// # Returns
     /// The cosine similarity between the two tables as a float value between 0 and 1.
     pub fn cosine(&self, other: &KmerCountTable) -> f64 {

--- a/src/python/tests/test_metrics.py
+++ b/src/python/tests/test_metrics.py
@@ -6,6 +6,7 @@ import pytest
 
 # Cosine similarity tests
 
+
 def test_cosine_similarity_identical_tables():
     """
     Test cosine similarity for two identical KmerCountTable objects.
@@ -162,10 +163,11 @@ def test_cosine_similarity_partial_overlap():
 import pytest
 from oxli import KmerCountTable
 
+
 def test_jaccard_similarity_identical_tables():
     """
     Test Jaccard similarity for two identical KmerCountTable objects.
-    
+
     The Jaccard similarity should be 1.0 because both tables contain exactly the same k-mers.
     """
     kct1 = KmerCountTable(ksize=4)
@@ -185,10 +187,11 @@ def test_jaccard_similarity_identical_tables():
     # Jaccard similarity should be 1.0 for identical sets
     assert kct1.jaccard(kct2) == 1.0
 
+
 def test_jaccard_similarity_different_tables():
     """
     Test Jaccard similarity for two KmerCountTable objects with different k-mers.
-    
+
     The Jaccard similarity will be less than 1.0 because the sets of k-mers differ.
     """
     kct1 = KmerCountTable(ksize=4)
@@ -204,10 +207,11 @@ def test_jaccard_similarity_different_tables():
     # Expected result: 0 overlap between the sets
     assert kct1.jaccard(kct2) == 0.0
 
+
 def test_jaccard_similarity_partial_overlap():
     """
     Test Jaccard similarity for two KmerCountTable objects with partial overlap in k-mers.
-    
+
     The Jaccard similarity should be greater than 0.0 but less than 1.0 because there are overlapping k-mers.
     """
     kct1 = KmerCountTable(ksize=4)
@@ -217,7 +221,7 @@ def test_jaccard_similarity_partial_overlap():
     kct1["AAAA"] = 5
     kct1["AATT"] = 1
     kct1["TTTC"] = 2
-    
+
     # Set k-mer counts for kct2
     kct2["AAAA"] = 2
     kct2["AATT"] = 1
@@ -226,10 +230,11 @@ def test_jaccard_similarity_partial_overlap():
     # Calculate expected Jaccard similarity: intersection {AAAA, AATT}, union {AAAA, TTTT, AATT, GGGG}
     assert kct1.jaccard(kct2) == 2 / 4
 
+
 def test_jaccard_similarity_empty_table():
     """
     Test Jaccard similarity for two KmerCountTable objects where one is empty.
-    
+
     The Jaccard similarity should be 0.0 because one set is empty, and the union is non-empty.
     """
     kct1 = KmerCountTable(ksize=4)
@@ -242,10 +247,11 @@ def test_jaccard_similarity_empty_table():
     # kct2 is empty
     assert kct1.jaccard(kct2) == 0.0
 
+
 def test_jaccard_similarity_both_empty():
     """
     Test Jaccard similarity for two empty KmerCountTable objects.
-    
+
     The Jaccard similarity should be 1.0 because both sets are empty, and thus identical.
     """
     kct1 = KmerCountTable(ksize=4)
@@ -253,4 +259,3 @@ def test_jaccard_similarity_both_empty():
 
     # Both tables are empty
     assert kct1.jaccard(kct2) == 1.0
-

--- a/src/python/tests/test_metrics.py
+++ b/src/python/tests/test_metrics.py
@@ -4,6 +4,7 @@ from scipy.spatial.distance import cosine
 import numpy as np
 import pytest
 
+# Cosine similarity tests
 
 def test_cosine_similarity_identical_tables():
     """
@@ -157,6 +158,99 @@ def test_cosine_similarity_partial_overlap():
     assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
 
 
-# Jaccard
+# Jaccard coefficient similarity tests
+import pytest
+from oxli import KmerCountTable
 
-# Jaccard with setops
+def test_jaccard_similarity_identical_tables():
+    """
+    Test Jaccard similarity for two identical KmerCountTable objects.
+    
+    The Jaccard similarity should be 1.0 because both tables contain exactly the same k-mers.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Manually set identical k-mer counts for both tables
+    kct1["AAAA"] = 5
+    kct1["TTTC"] = 2
+    kct1["AATT"] = 3
+    kct1["GGGG"] = 1
+
+    kct2["AAAA"] = 5
+    kct2["TTTC"] = 2
+    kct2["AATT"] = 3
+    kct2["GGGG"] = 1
+
+    # Jaccard similarity should be 1.0 for identical sets
+    assert kct1.jaccard(kct2) == 1.0
+
+def test_jaccard_similarity_different_tables():
+    """
+    Test Jaccard similarity for two KmerCountTable objects with different k-mers.
+    
+    The Jaccard similarity will be less than 1.0 because the sets of k-mers differ.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Set different k-mer counts for both tables
+    kct1["AAAA"] = 5
+    kct1["TTTC"] = 2
+
+    kct2["AATT"] = 3
+    kct2["GGGG"] = 4
+
+    # Expected result: 0 overlap between the sets
+    assert kct1.jaccard(kct2) == 0.0
+
+def test_jaccard_similarity_partial_overlap():
+    """
+    Test Jaccard similarity for two KmerCountTable objects with partial overlap in k-mers.
+    
+    The Jaccard similarity should be greater than 0.0 but less than 1.0 because there are overlapping k-mers.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Set k-mer counts for kct1
+    kct1["AAAA"] = 5
+    kct1["AATT"] = 1
+    kct1["TTTC"] = 2
+    
+    # Set k-mer counts for kct2
+    kct2["AAAA"] = 2
+    kct2["AATT"] = 1
+    kct2["GGGG"] = 4
+
+    # Calculate expected Jaccard similarity: intersection {AAAA, AATT}, union {AAAA, TTTT, AATT, GGGG}
+    assert kct1.jaccard(kct2) == 2 / 4
+
+def test_jaccard_similarity_empty_table():
+    """
+    Test Jaccard similarity for two KmerCountTable objects where one is empty.
+    
+    The Jaccard similarity should be 0.0 because one set is empty, and the union is non-empty.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Set counts for kct1
+    kct1["AAAA"] = 5
+    kct1["TTTC"] = 5
+
+    # kct2 is empty
+    assert kct1.jaccard(kct2) == 0.0
+
+def test_jaccard_similarity_both_empty():
+    """
+    Test Jaccard similarity for two empty KmerCountTable objects.
+    
+    The Jaccard similarity should be 1.0 because both sets are empty, and thus identical.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Both tables are empty
+    assert kct1.jaccard(kct2) == 1.0
+

--- a/src/python/tests/test_metrics.py
+++ b/src/python/tests/test_metrics.py
@@ -1,8 +1,9 @@
 from math import isclose
-from oxli import KmerCountTable
-from scipy.spatial.distance import cosine
 import numpy as np
 import pytest
+from scipy.spatial.distance import cosine
+
+from oxli import KmerCountTable
 
 # Cosine similarity tests
 
@@ -35,6 +36,7 @@ def test_cosine_similarity_identical_tables():
     # Cosine similarity between identical tables should be 1.0
     # Allow value within 0.001%
     assert isclose(kct1.cosine(kct2), 1.0, rel_tol=1e-5)
+    assert isclose(kct2.cosine(kct1), 1.0, rel_tol=1e-5)
 
     # Using scipy to calculate the expected value
     vector1 = [5, 3, 1, 4, 6]
@@ -43,6 +45,7 @@ def test_cosine_similarity_identical_tables():
 
     # Allow value within 0.001%
     assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+    assert isclose(kct2.cosine(kct1), expected_cosine_sim, rel_tol=1e-5)
 
 
 def test_cosine_similarity_different_tables():
@@ -77,6 +80,7 @@ def test_cosine_similarity_different_tables():
 
     # Allow value within 0.001%
     assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+    assert isclose(kct2.cosine(kct1), expected_cosine_sim, rel_tol=1e-5)
 
 
 def test_cosine_similarity_empty_table():
@@ -111,6 +115,7 @@ def test_cosine_similarity_empty_table():
     expected_cosine_sim = 1 - cosine(vector1, vector2)
 
     assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+    assert isclose(kct2.cosine(kct1), expected_cosine_sim, rel_tol=1e-5)
 
 
 def test_cosine_similarity_both_empty():
@@ -123,6 +128,7 @@ def test_cosine_similarity_both_empty():
 
     # Cosine similarity should be 0.0 for two empty tables
     assert kct1.cosine(kct2) == 0.0
+    assert kct2.cosine(kct1) == 0.0
 
 
 def test_cosine_similarity_partial_overlap():
@@ -136,7 +142,7 @@ def test_cosine_similarity_partial_overlap():
     kct2 = KmerCountTable(ksize=4)
 
     # Manually set k-mer counts for kct1
-    kct1["AAAA"] = 0  # Not in kct2
+    # kct1["AAAA"] = 0  # Not in kct2
     kct1["AATT"] = 3
     kct1["GGGG"] = 1
     kct1["CCAA"] = 4
@@ -157,11 +163,10 @@ def test_cosine_similarity_partial_overlap():
 
     # Cosine similarity is expected to be > 0 but < 1
     assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+    assert isclose(kct2.cosine(kct1), expected_cosine_sim, rel_tol=1e-5)
 
 
 # Jaccard coefficient similarity tests
-import pytest
-from oxli import KmerCountTable
 
 
 def test_jaccard_similarity_identical_tables():
@@ -186,6 +191,7 @@ def test_jaccard_similarity_identical_tables():
 
     # Jaccard similarity should be 1.0 for identical sets
     assert kct1.jaccard(kct2) == 1.0
+    assert kct2.jaccard(kct1) == 1.0
 
 
 def test_jaccard_similarity_different_tables():
@@ -206,6 +212,7 @@ def test_jaccard_similarity_different_tables():
 
     # Expected result: 0 overlap between the sets
     assert kct1.jaccard(kct2) == 0.0
+    assert kct2.jaccard(kct1) == 0.0
 
 
 def test_jaccard_similarity_partial_overlap():
@@ -229,6 +236,7 @@ def test_jaccard_similarity_partial_overlap():
 
     # Calculate expected Jaccard similarity: intersection {AAAA, AATT}, union {AAAA, TTTT, AATT, GGGG}
     assert kct1.jaccard(kct2) == 2 / 4
+    assert kct2.jaccard(kct1) == 2 / 4
 
 
 def test_jaccard_similarity_empty_table():
@@ -246,6 +254,7 @@ def test_jaccard_similarity_empty_table():
 
     # kct2 is empty
     assert kct1.jaccard(kct2) == 0.0
+    assert kct2.jaccard(kct1) == 0.0
 
 
 def test_jaccard_similarity_both_empty():
@@ -259,3 +268,4 @@ def test_jaccard_similarity_both_empty():
 
     # Both tables are empty
     assert kct1.jaccard(kct2) == 1.0
+    assert kct2.jaccard(kct1) == 1.0

--- a/src/python/tests/test_metrics.py
+++ b/src/python/tests/test_metrics.py
@@ -1,0 +1,162 @@
+from math import isclose
+from oxli import KmerCountTable
+from scipy.spatial.distance import cosine
+import numpy as np
+import pytest
+
+
+def test_cosine_similarity_identical_tables():
+    """
+    Test cosine similarity for two identical KmerCountTable objects.
+
+    The cosine similarity should be 1.0 because the vectors representing
+    the k-mer counts are exactly the same, meaning the angle between them
+    is 0 degrees (cos(0) = 1).
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Manually set k-mer counts
+    kct1["AAAA"] = 5
+    kct1["AATT"] = 3
+    kct1["GGGG"] = 1
+    kct1["CCAA"] = 4
+    kct1["ATTG"] = 6
+
+    # Copy the exact same counts to kct2
+    kct2["AAAA"] = 5
+    kct2["AATT"] = 3
+    kct2["GGGG"] = 1
+    kct2["CCAA"] = 4
+    kct2["ATTG"] = 6
+
+    # Cosine similarity between identical tables should be 1.0
+    # Allow value within 0.001%
+    assert isclose(kct1.cosine(kct2), 1.0, rel_tol=1e-5)
+
+    # Using scipy to calculate the expected value
+    vector1 = [5, 3, 1, 4, 6]
+    vector2 = [5, 3, 1, 4, 6]
+    expected_cosine_sim = 1 - cosine(vector1, vector2)
+
+    # Allow value within 0.001%
+    assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+
+
+def test_cosine_similarity_different_tables():
+    """
+    Test cosine similarity for two different KmerCountTable objects.
+
+    The cosine similarity will be less than 1.0 since the vectors
+    are not identical. We will calculate the expected cosine
+    similarity using scipy.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Manually set k-mer counts for kct1
+    kct1["AAAA"] = 4
+    kct1["AATT"] = 3
+    kct1["GGGG"] = 1
+    kct1["CCAA"] = 4
+    kct1["ATTG"] = 6
+
+    # Manually set different counts for kct2
+    kct2["AAAA"] = 5
+    kct2["AATT"] = 3
+    kct2["GGGG"] = 1
+    kct2["CCAA"] = 4
+    kct2["ATTG"] = 0
+
+    # Using scipy to calculate the expected value
+    vector1 = [4, 3, 1, 4, 6]
+    vector2 = [5, 3, 1, 4, 0]
+    expected_cosine_sim = 1 - cosine(vector1, vector2)
+
+    # Allow value within 0.001%
+    assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+
+
+def test_cosine_similarity_empty_table():
+    """
+    Test cosine similarity for two KmerCountTable objects where one is empty.
+
+    The cosine similarity should be 0.0 because the dot product with an
+    empty table will result in zero, making the numerator of the cosine
+    similarity formula zero.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Set counts for kct1
+    kct1["AAAA"] = 5
+    kct1["TTTG"] = 10
+
+    # Leave kct2 empty
+
+    # Cosine similarity should be 0 since one table is empty
+    assert kct1.cosine(kct2) == 0.0
+
+    # Set kct2 with 1 non-overlapping kmer
+    kct2["ATTG"] = 1
+
+    # Cosine similarity should be 0 since no shared kmers
+    assert kct1.cosine(kct2) == 0.0
+
+    # Using scipy for comparison
+    vector1 = [5, 10, 0]
+    vector2 = [0, 0, 1]  # Representing the empty table with no overlap
+    expected_cosine_sim = 1 - cosine(vector1, vector2)
+
+    assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+
+
+def test_cosine_similarity_both_empty():
+    """
+    Test cosine similarity for two empty KmerCountTable objects.
+    """
+    # Both tables are empty
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Cosine similarity should be 0.0 for two empty tables
+    assert kct1.cosine(kct2) == 0.0
+
+
+def test_cosine_similarity_partial_overlap():
+    """
+    Test cosine similarity for two KmerCountTable objects with partial overlap in k-mers.
+
+    The cosine similarity should be less than 1.0 but greater than 0.0 because
+    the tables have overlapping k-mers, but their counts differ.
+    """
+    kct1 = KmerCountTable(ksize=4)
+    kct2 = KmerCountTable(ksize=4)
+
+    # Manually set k-mer counts for kct1
+    kct1["AAAA"] = 0  # Not in kct2
+    kct1["AATT"] = 3
+    kct1["GGGG"] = 1
+    kct1["CCAA"] = 4
+    kct1["ATTG"] = 0
+    kct1["AGAT"] = 0  # Set but not in either
+
+    # Manually set k-mer counts for kct2
+    kct2["AAAA"] = 5
+    kct2["AATT"] = 4  # Diff value to kct1
+    kct2["GGGG"] = 1
+    kct2["CCAA"] = 4
+    kct2["ATTG"] = 1  # Not in kct1
+
+    # Using scipy for comparison
+    vector1 = [0, 3, 1, 4, 0, 0]
+    vector2 = [5, 4, 1, 4, 1, 0]
+    expected_cosine_sim = 1 - cosine(vector1, vector2)
+
+    # Cosine similarity is expected to be > 0 but < 1
+    assert isclose(kct1.cosine(kct2), expected_cosine_sim, rel_tol=1e-5)
+
+
+# Jaccard
+
+# Jaccard with setops


### PR DESCRIPTION
This PR will add simple distance metrics for comparing count tables. Starting with Jaccard and Cosine Similarity.

Closes #39 

This initial commit adds `cosine()` method to calculate cosine similarity between two `KmerCountTables`.
Have attempted to use Rayon to make hash lookup multithreaded.

@ctb can you check the logic on this + look over the tests?

I've benchmarked against the scipy cosine function (allowing for a 0.001% margin - not sure where the diff is coming from)

In the test `test_cosine_similarity_identical_tables()` my function is giving 0.999999999 instead of 1. No idea why this is happening. 