### PR TITLE
Do format updates on top of current commit rather than head.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.sha }}
       - uses: chartboost/ruff-action@v1
         with:
           src: './src/python'


### PR DESCRIPTION
Ruff github action was checking out head of PR before making edits, this resulted in conflicts with the incoming commit if they edit the same python files. 

See if checkout incoming commit fixes this.