### PR TITLE
MRG: use 'expect' instead of 'unwrap'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl KmerCountTable {
                 42,
             );
 
-            let hashval = hashes.next().unwrap();
+            let hashval = hashes.next().expect("error hashing this k-mer");
             Ok(hashval?)
         }
     }
@@ -88,7 +88,7 @@ impl KmerCountTable {
                 "kmer size does not match count table ksize",
             ))
         } else {
-            let hashval = self.hash_kmer(kmer).unwrap();
+            let hashval = self.hash_kmer(kmer).expect("error hashing this k-mer");
 
             let count = match self.counts.get(&hashval) {
                 Some(count) => count,


### PR DESCRIPTION
This avoids panics without an error message; the error conditions still shouldn't occur, tho.

See Unwrapping in [this blog post](https://www.shuttle.rs/blog/2022/06/30/error-handling).